### PR TITLE
fix: resolve HELIX image proxy 404 due to cache limit bug

### DIFF
--- a/backend/src/aimdl_dashboard_api/app.py
+++ b/backend/src/aimdl_dashboard_api/app.py
@@ -16,6 +16,7 @@ from .discovery import (
     resolve_instrument_folders,
     refresh_cache,
     get_cached_visualizations,
+    get_cached_viz_by_id,
     get_instrument_counts,
 )
 from .models import Visualization, VisualizationList
@@ -120,10 +121,9 @@ def get_visualization_image(item_id: str):
     if not girder.connected:
         raise HTTPException(503, "Girder not connected")
 
-    items = get_cached_visualizations()
-    viz = next((v for v in items if v["id"] == item_id), None)
+    viz = get_cached_viz_by_id(item_id)
     if not viz:
-        raise HTTPException(404, "Visualization not found")
+        raise HTTPException(404, "Visualization not found in cache")
 
     try:
         data = girder.download_file_bytes(viz["file_id"])

--- a/backend/src/aimdl_dashboard_api/discovery.py
+++ b/backend/src/aimdl_dashboard_api/discovery.py
@@ -16,6 +16,8 @@ _cache = {
     "instrument_folder_ids": {},
 }
 
+_cache_by_id = {}
+
 
 def extract_igsn(folder_name, instrument):
     if instrument == "HELIX" and "_alpss" in folder_name:
@@ -177,6 +179,9 @@ def refresh_cache(per_instrument_limit=30):
         all_items.extend(items)
     all_items.sort(key=lambda x: x["created"], reverse=True)
     _cache["visualizations"] = all_items
+    _cache_by_id.clear()
+    for item in all_items:
+        _cache_by_id[item["id"]] = item
     _cache["last_refresh"] = time.time()
     elapsed = time.time() - start
     logger.info(
@@ -196,6 +201,11 @@ def get_cached_visualizations(instrument=None, igsn=None, limit=30, since=None):
         items = [v for v in items if v["created"] > since.isoformat()]
 
     return items[:limit]
+
+
+def get_cached_viz_by_id(item_id):
+    """Look up a single visualization by Girder item ID. O(1)."""
+    return _cache_by_id.get(item_id)
 
 
 def get_instrument_counts():


### PR DESCRIPTION
## Summary

- The image proxy endpoint called `get_cached_visualizations()` with a default limit of 30. HELIX items (older timestamps) sorted beyond position 30 and returned 404 when the proxy tried to look them up, causing broken images.
- Added `_cache_by_id` dict index to `discovery.py` for O(1) lookup
- Updated image proxy endpoint to use `get_cached_viz_by_id()` instead of filtering a limited list

## Test plan

- [ ] HELIX image proxy returns 200 with PNG bytes
- [ ] MAXIMA image proxy still works
- [ ] No regressions in `/api/visualizations` list endpoint

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)