### PR TITLE
feat: add zoom control for dynamic grid scaling

### DIFF
--- a/backend/src/aimdl_dashboard_api/discovery.py
+++ b/backend/src/aimdl_dashboard_api/discovery.py
@@ -179,14 +179,17 @@ def refresh_cache(per_instrument_limit=30):
         all_items.extend(items)
     all_items.sort(key=lambda x: x["created"], reverse=True)
     _cache["visualizations"] = all_items
+
+    # Build ID index for O(1) lookup by the image proxy
     _cache_by_id.clear()
     for item in all_items:
         _cache_by_id[item["id"]] = item
+
     _cache["last_refresh"] = time.time()
     elapsed = time.time() - start
     logger.info(
-        "Cache refreshed: %d visualizations in %.1fs",
-        len(_cache["visualizations"]), elapsed,
+        "Cache refreshed: %d visualizations (%d indexed) in %.1fs",
+        len(_cache["visualizations"]), len(_cache_by_id), elapsed,
     )
 
 

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -13,6 +13,11 @@ export default function Dashboard() {
   const [filter, setFilter] = useState("ALL");
   const [viewMode, setViewMode] = useState("stream");
   const [selectedViz, setSelectedViz] = useState(null);
+  const [zoom, setZoom] = useState(() => {
+    const params = new URLSearchParams(window.location.search);
+    const z = parseInt(params.get("zoom"));
+    return (z >= 1 && z <= 5) ? z : 3;
+  });
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -25,6 +30,16 @@ export default function Dashboard() {
       setViewMode(view);
     }
   }, []);
+
+  useEffect(() => {
+    const url = new URL(window.location);
+    if (zoom === 3) {
+      url.searchParams.delete("zoom");
+    } else {
+      url.searchParams.set("zoom", zoom);
+    }
+    window.history.replaceState({}, "", url);
+  }, [zoom]);
 
   const { data, filtered, counts, lastUpdate } = useVizStream({ filter });
 
@@ -39,7 +54,7 @@ export default function Dashboard() {
         flexDirection: "column",
       }}
     >
-      <Header viewMode={viewMode} setViewMode={setViewMode} />
+      <Header viewMode={viewMode} setViewMode={setViewMode} zoom={zoom} setZoom={setZoom} />
 
       <div
         style={{
@@ -86,7 +101,7 @@ export default function Dashboard() {
         {viewMode === "spotlight" && <SpotlightView filtered={filtered} />}
 
         {viewMode === "stream" && (
-          <StreamView filtered={filtered} onSelect={setSelectedViz} />
+          <StreamView filtered={filtered} onSelect={setSelectedViz} zoom={zoom} />
         )}
 
         {viewMode === "sample" && (

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,6 +1,7 @@
 import ViewModeSelector from "./ViewModeSelector";
+import ZoomControl from "./ZoomControl";
 
-export default function Header({ viewMode, setViewMode }) {
+export default function Header({ viewMode, setViewMode, zoom, setZoom }) {
   return (
     <div
       style={{
@@ -38,7 +39,11 @@ export default function Header({ viewMode, setViewMode }) {
           </div>
         </div>
       </div>
-      <ViewModeSelector mode={viewMode} setMode={setViewMode} />
+      <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+        <ViewModeSelector mode={viewMode} setMode={setViewMode} />
+        <div style={{ width: "1px", height: "20px", background: "#1e2740" }} />
+        <ZoomControl zoom={zoom} setZoom={setZoom} />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/StreamView.jsx
+++ b/frontend/src/components/StreamView.jsx
@@ -1,13 +1,17 @@
 import VizCard from "./VizCard";
+import { ZOOM_LEVELS } from "./ZoomControl";
 
-export default function StreamView({ filtered, onSelect }) {
+export default function StreamView({ filtered, onSelect, zoom = 3 }) {
+  const minWidth = ZOOM_LEVELS.find((z) => z.level === zoom)?.minWidth || 280;
+
   return (
     <div
       style={{
         display: "grid",
-        gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
+        gridTemplateColumns: `repeat(auto-fill, minmax(${minWidth}px, 1fr))`,
         gap: "14px",
         animation: "slideIn 0.3s ease",
+        transition: "all 0.3s ease",
       }}
     >
       {filtered.map((viz, i) => (

--- a/frontend/src/components/ZoomControl.jsx
+++ b/frontend/src/components/ZoomControl.jsx
@@ -1,0 +1,77 @@
+export const ZOOM_LEVELS = [
+  { level: 1, label: "XL", minWidth: 500 },
+  { level: 2, label: "L",  minWidth: 380 },
+  { level: 3, label: "M",  minWidth: 280 },
+  { level: 4, label: "S",  minWidth: 200 },
+  { level: 5, label: "XS", minWidth: 150 },
+];
+
+const buttonStyle = {
+  width: "24px",
+  height: "24px",
+  border: "1px solid #1e2740",
+  borderRadius: "4px",
+  background: "transparent",
+  color: "#6b7a99",
+  fontFamily: "'IBM Plex Mono', monospace",
+  fontSize: "13px",
+  cursor: "pointer",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  transition: "all 0.2s",
+};
+
+export default function ZoomControl({ zoom, setZoom }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+      <button
+        onClick={() => setZoom(Math.max(1, zoom - 1))}
+        style={{
+          ...buttonStyle,
+          opacity: zoom <= 1 ? 0.3 : 1,
+        }}
+        disabled={zoom <= 1}
+        title="Zoom in (larger cards)"
+      >
+        -
+      </button>
+      <div style={{ display: "flex", gap: "3px", alignItems: "center" }}>
+        {ZOOM_LEVELS.map((z) => (
+          <div
+            key={z.level}
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: "50%",
+              background: z.level === zoom ? "#4ECDC4" : "#1e2740",
+              boxShadow: z.level === zoom ? "0 0 6px #4ECDC440" : "none",
+              transition: "all 0.2s",
+            }}
+          />
+        ))}
+      </div>
+      <button
+        onClick={() => setZoom(Math.min(5, zoom + 1))}
+        style={{
+          ...buttonStyle,
+          opacity: zoom >= 5 ? 0.3 : 1,
+        }}
+        disabled={zoom >= 5}
+        title="Zoom out (smaller cards)"
+      >
+        +
+      </button>
+      <span
+        style={{
+          fontFamily: "'IBM Plex Mono', monospace",
+          fontSize: "9px",
+          color: "#3d4d6b",
+          marginLeft: "2px",
+        }}
+      >
+        {ZOOM_LEVELS.find((z) => z.level === zoom)?.label}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a zoom control (+/- buttons with level indicator) to the header bar that controls visualization card size in the grid
- 5 zoom levels: XL (500px, ~2 cols) down to XS (150px, ~6+ cols)
- Default level 3 (M, 280px) matches previous behavior exactly
- Zoom level persists in URL parameter `?zoom=N` for kiosk configuration

## Changes

- Created `ZoomControl` component with +/- buttons and dot indicator
- Added zoom state to Dashboard, passed to Header and StreamView
- StreamView grid `minmax` value driven by zoom level
- Zoom persists in URL parameter `?zoom=N`

## Test plan

- [ ] All 5 zoom levels produce expected column counts
- [ ] Default level 3 matches previous behavior exactly
- [ ] Zoom persists across page reloads via URL parameter
- [ ] Spotlight view unaffected

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)