### PR TITLE
feat: group MAXIMA scan/xrd pairs side by side

### DIFF
--- a/backend/src/aimdl_dashboard_api/app.py
+++ b/backend/src/aimdl_dashboard_api/app.py
@@ -106,6 +106,8 @@ def list_visualizations(
             file_id=v["file_id"],
             thumbnail_url=f"/api/visualizations/{v['id']}/image",
             metadata=v["metadata"],
+            pair_key=v.get("pair_key"),
+            pair_role=v.get("pair_role"),
         )
         for v in items
     ]

--- a/backend/src/aimdl_dashboard_api/discovery.py
+++ b/backend/src/aimdl_dashboard_api/discovery.py
@@ -1,3 +1,4 @@
+import os
 import re
 import logging
 import time
@@ -9,6 +10,30 @@ from .girder_client import girder
 logger = logging.getLogger(__name__)
 
 IGSN_PATTERN = re.compile(r"(JH[A-Z]{4}\d{5}(-\d+)?)")
+
+
+def _extract_pair_info(filename):
+    """Extract pair key and role from a MAXIMA filename.
+
+    Returns (pair_key, pair_role) or (None, None) if not part of a pair.
+    Example:
+      'JHXMAL00005_..._0_765_scan.png' -> ('JHXMAL00005_..._0_765', 'scan')
+      'JHXMAL00005_..._0_765_xrd.png'  -> ('JHXMAL00005_..._0_765', 'xrd')
+    """
+    stem = os.path.splitext(filename)[0]
+    if stem.endswith("_scan"):
+        return stem[:-5], "scan"
+    elif stem.endswith("_xrd"):
+        return stem[:-4], "xrd"
+    return None, None
+
+
+def _pair_sort_key(item):
+    """Sort key that groups pairs together, scan before xrd."""
+    pk = item.get("pair_key") or item["name"]
+    role_order = {"scan": 0, "xrd": 1}
+    role = role_order.get(item.get("pair_role"), 2)
+    return (item.get("created", ""), pk, role)
 
 _cache = {
     "visualizations": [],
@@ -106,6 +131,7 @@ def _discover_maxima(base_folder_id, limit):
             folder_path = f"MAXIMA / {exp_folder['name']}"
             if raw_folder:
                 folder_path += " / raw"
+            pair_key, pair_role = _extract_pair_info(item["name"])
             results.append({
                 "id": item["_id"],
                 "name": item["name"],
@@ -116,11 +142,14 @@ def _discover_maxima(base_folder_id, limit):
                 "created": item.get("created", datetime.now(timezone.utc).isoformat()),
                 "file_id": file_id,
                 "metadata": item.get("meta", {}),
+                "pair_key": pair_key,
+                "pair_role": pair_role,
             })
 
         if len(results) >= limit:
             break
 
+    results.sort(key=_pair_sort_key, reverse=True)
     return results
 
 

--- a/backend/src/aimdl_dashboard_api/models.py
+++ b/backend/src/aimdl_dashboard_api/models.py
@@ -13,6 +13,8 @@ class Visualization(BaseModel):
     file_id: str
     thumbnail_url: str
     metadata: dict = {}
+    pair_key: str | None = None
+    pair_role: str | None = None
 
 
 class VisualizationList(BaseModel):

--- a/frontend/src/components/StreamView.jsx
+++ b/frontend/src/components/StreamView.jsx
@@ -1,8 +1,30 @@
 import VizCard from "./VizCard";
 import { ZOOM_LEVELS } from "./ZoomControl";
 
+function groupIntoPairs(items) {
+  const result = [];
+  const seen = new Set();
+
+  for (let i = 0; i < items.length; i++) {
+    if (seen.has(items[i].id)) continue;
+    seen.add(items[i].id);
+
+    if (items[i].pairKey) {
+      const partner = items[i + 1];
+      if (partner && partner.pairKey === items[i].pairKey) {
+        seen.add(partner.id);
+        result.push({ type: "pair", items: [items[i], partner] });
+        continue;
+      }
+    }
+    result.push({ type: "single", items: [items[i]] });
+  }
+  return result;
+}
+
 export default function StreamView({ filtered, onSelect, zoom = 3 }) {
   const minWidth = ZOOM_LEVELS.find((z) => z.level === zoom)?.minWidth || 280;
+  const groups = groupIntoPairs(filtered);
 
   return (
     <div
@@ -14,20 +36,40 @@ export default function StreamView({ filtered, onSelect, zoom = 3 }) {
         transition: "all 0.3s ease",
       }}
     >
-      {filtered.map((viz, i) => (
-        <div
-          key={viz.id}
-          style={{
-            animation: `slideIn 0.3s ease ${Math.min(i * 0.03, 0.3)}s both`,
-          }}
-        >
-          <VizCard
-            viz={viz}
-            spotlight={i === 0}
-            onClick={() => onSelect(viz)}
-          />
-        </div>
-      ))}
+      {groups.map((group, gi) =>
+        group.type === "pair" ? (
+          <div
+            key={group.items[0].id}
+            style={{
+              gridColumn: "span 2",
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr",
+              gap: "8px",
+              border: "1px solid #1e274040",
+              borderRadius: "10px",
+              padding: "6px",
+              background: "#0a0e1880",
+            }}
+          >
+            {group.items.map((viz) => (
+              <VizCard key={viz.id} viz={viz} onClick={() => onSelect(viz)} />
+            ))}
+          </div>
+        ) : (
+          <div
+            key={group.items[0].id}
+            style={{
+              animation: `slideIn 0.3s ease ${Math.min(gi * 0.03, 0.3)}s both`,
+            }}
+          >
+            <VizCard
+              viz={group.items[0]}
+              spotlight={gi === 0}
+              onClick={() => onSelect(group.items[0])}
+            />
+          </div>
+        )
+      )}
     </div>
   );
 }

--- a/frontend/src/components/VizCard.jsx
+++ b/frontend/src/components/VizCard.jsx
@@ -28,6 +28,26 @@ export default function VizCard({ viz, spotlight = false, onClick }) {
         e.currentTarget.style.transform = "translateY(0)";
       }}
     >
+      {viz.pairRole && (
+        <div
+          style={{
+            position: "absolute",
+            top: 8,
+            right: 8,
+            zIndex: 2,
+            background: `${instColor}20`,
+            border: `1px solid ${instColor}40`,
+            borderRadius: "4px",
+            padding: "2px 8px",
+            fontSize: "9px",
+            fontFamily: "'IBM Plex Mono', monospace",
+            color: instColor,
+            textTransform: "uppercase",
+          }}
+        >
+          {viz.pairRole}
+        </div>
+      )}
       {viz.status === "processing" && (
         <div
           style={{

--- a/frontend/src/hooks/useVizStream.js
+++ b/frontend/src/hooks/useVizStream.js
@@ -36,6 +36,8 @@ function mapApiViz(viz) {
     igsn: viz.igsn,
     fileId: viz.file_id,
     metadata: viz.metadata,
+    pairKey: viz.pair_key || null,
+    pairRole: viz.pair_role || null,
     status: "complete",
   };
 }


### PR DESCRIPTION
## Summary

- MAXIMA produces natural pairs of PNGs for each measurement point: a 2D detector scan image (`_scan.png`) and an integrated XRD pattern (`_xrd.png`). This PR groups them side by side in the dashboard grid.

## Changes

**Backend:**
- Added `_extract_pair_info()` to parse scan/xrd filenames in `discovery.py`
- Added `pair_key` and `pair_role` fields to discovery results and `Visualization` model
- Sorted paired MAXIMA items adjacently (scan before xrd)

**Frontend:**
- `StreamView` groups paired items into `span 2` grid containers for side-by-side display
- `VizCard` shows SCAN/XRD role badge on paired items
- `useVizStream` maps `pair_key` and `pair_role` from API response

## Test plan

- [ ] Paired MAXIMA items render side by side in StreamView
- [ ] Unpaired items (HELIX, non-scan/xrd MAXIMA) render normally
- [ ] Pair role labels (SCAN/XRD) appear on VizCards
- [ ] Mock mode still works without regressions
- [ ] No regressions in Spotlight or Sample Comparison views

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)