### PR TITLE
feat: add movie mode for animating across sample positions

### DIFF
--- a/backend/src/aimdl_dashboard_api/app.py
+++ b/backend/src/aimdl_dashboard_api/app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Optional
@@ -19,7 +20,7 @@ from .discovery import (
     get_cached_viz_by_id,
     get_instrument_counts,
 )
-from .models import Visualization, VisualizationList
+from .models import Visualization, VisualizationList, SampleVisualizationList
 
 logging.basicConfig(
     level=logging.INFO,
@@ -108,6 +109,7 @@ def list_visualizations(
             metadata=v["metadata"],
             pair_key=v.get("pair_key"),
             pair_role=v.get("pair_role"),
+            position=v.get("position"),
         )
         for v in items
     ]
@@ -115,6 +117,46 @@ def list_visualizations(
         items=viz_list,
         total=len(viz_list),
         instrument_counts=counts,
+    )
+
+
+@app.get("/api/visualizations/sample/{igsn}", response_model=SampleVisualizationList)
+def get_sample_visualizations(
+    igsn: str,
+    instrument: Optional[str] = Query(None),
+):
+    """Return all visualizations for a sample, sorted by position."""
+    items = get_cached_visualizations(igsn=igsn, limit=500)
+    if instrument:
+        items = [v for v in items if v["instrument"] == instrument]
+
+    def position_sort_key(v):
+        pos = v.get("position") or ""
+        parts = re.findall(r'\d+', pos)
+        return tuple(int(p) for p in parts) if parts else (pos,)
+
+    items.sort(key=position_sort_key)
+
+    viz_list = [
+        Visualization(
+            id=v["id"],
+            name=v["name"],
+            instrument=v["instrument"],
+            igsn=v["igsn"],
+            sample=v["sample"],
+            folder_path=v["folder_path"],
+            created=v["created"],
+            file_id=v["file_id"],
+            thumbnail_url=f"/api/visualizations/{v['id']}/image",
+            metadata=v["metadata"],
+            pair_key=v.get("pair_key"),
+            pair_role=v.get("pair_role"),
+            position=v.get("position"),
+        )
+        for v in items
+    ]
+    return SampleVisualizationList(
+        items=viz_list, total=len(viz_list), igsn=igsn,
     )
 
 

--- a/backend/src/aimdl_dashboard_api/discovery.py
+++ b/backend/src/aimdl_dashboard_api/discovery.py
@@ -12,6 +12,23 @@ logger = logging.getLogger(__name__)
 IGSN_PATTERN = re.compile(r"(JH[A-Z]{4}\d{5}(-\d+)?)")
 
 
+def _extract_position(folder_name, instrument):
+    """Extract a position identifier from the folder name."""
+    if instrument == "MAXIMA":
+        # Pattern: {IGSN}_{24-hex-chars}_{position}_{YYYY-MM-DD}_{time}
+        m = re.match(
+            r'^[A-Z0-9-]+_[0-9a-f]{24}_(.+?)_\d{4}-\d{2}-\d{2}_',
+            folder_name
+        )
+        if m:
+            return m.group(1)
+    elif instrument == "HELIX":
+        m = re.search(r'shot(\d+)', folder_name)
+        if m:
+            return f"shot{m.group(1)}"
+    return None
+
+
 def _extract_pair_info(filename):
     """Extract pair key and role from a MAXIMA filename.
 
@@ -81,6 +98,7 @@ def _discover_helix(base_folder_id, limit):
                     continue
                 file_id = files[0]["_id"]
                 folder_path = f"HELIX / {igsn_folder['name']} / {shot_folder['name']}"
+                position = _extract_position(shot_folder["name"], "HELIX")
                 results.append({
                     "id": item["_id"],
                     "name": item["name"],
@@ -91,6 +109,7 @@ def _discover_helix(base_folder_id, limit):
                     "created": item.get("created", datetime.now(timezone.utc).isoformat()),
                     "file_id": file_id,
                     "metadata": item.get("meta", {}),
+                    "position": position,
                 })
 
             if len(results) >= limit:
@@ -132,6 +151,7 @@ def _discover_maxima(base_folder_id, limit):
             if raw_folder:
                 folder_path += " / raw"
             pair_key, pair_role = _extract_pair_info(item["name"])
+            position = _extract_position(exp_folder["name"], "MAXIMA")
             results.append({
                 "id": item["_id"],
                 "name": item["name"],
@@ -144,6 +164,7 @@ def _discover_maxima(base_folder_id, limit):
                 "metadata": item.get("meta", {}),
                 "pair_key": pair_key,
                 "pair_role": pair_role,
+                "position": position,
             })
 
         if len(results) >= limit:

--- a/backend/src/aimdl_dashboard_api/models.py
+++ b/backend/src/aimdl_dashboard_api/models.py
@@ -15,9 +15,16 @@ class Visualization(BaseModel):
     metadata: dict = {}
     pair_key: str | None = None
     pair_role: str | None = None
+    position: str | None = None
 
 
 class VisualizationList(BaseModel):
     items: list[Visualization]
     total: int
     instrument_counts: dict[str, int]
+
+
+class SampleVisualizationList(BaseModel):
+    items: list[Visualization]
+    total: int
+    igsn: str

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -6,6 +6,7 @@ import InstrumentTab from "./InstrumentTab";
 import StreamView from "./StreamView";
 import SpotlightView from "./SpotlightView";
 import SampleComparisonView from "./SampleComparisonView";
+import MovieView from "./MovieView";
 import VizDetailModal from "./VizDetailModal";
 import StatusBar from "./StatusBar";
 
@@ -26,7 +27,7 @@ export default function Dashboard() {
       setFilter(inst.toUpperCase());
     }
     const view = params.get("view");
-    if (view && ["stream", "spotlight", "sample"].includes(view)) {
+    if (view && ["stream", "spotlight", "sample", "movie"].includes(view)) {
       setViewMode(view);
     }
   }, []);
@@ -109,6 +110,8 @@ export default function Dashboard() {
             <SampleComparisonView data={filtered} />
           </div>
         )}
+
+        {viewMode === "movie" && <MovieView data={data} />}
       </div>
 
       {selectedViz && (

--- a/frontend/src/components/MovieView.jsx
+++ b/frontend/src/components/MovieView.jsx
@@ -1,0 +1,400 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { INSTRUMENTS, INSTRUMENT_COLORS, API_CONFIG } from "../config";
+import { mapApiViz } from "../hooks/useVizStream";
+import MockVisualization from "./MockVisualization";
+
+const SPEEDS = [0.5, 1, 2, 4];
+
+export default function MovieView({ data }) {
+  const [selectedIgsn, setSelectedIgsn] = useState(null);
+  const [selectedInstrument, setSelectedInstrument] = useState(null);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const [speed, setSpeed] = useState(1);
+  const [frames, setFrames] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const igsnOptions = useMemo(() => {
+    const counts = {};
+    data.forEach((v) => {
+      const key = v.igsn || v.sample;
+      if (key) counts[key] = (counts[key] || 0) + 1;
+    });
+    return Object.entries(counts)
+      .sort((a, b) => b[1] - a[1])
+      .map(([igsn]) => igsn);
+  }, [data]);
+
+  const instrumentOptions = useMemo(() => {
+    if (!selectedIgsn) return [];
+    const instruments = new Set();
+    data.forEach((v) => {
+      if ((v.igsn || v.sample) === selectedIgsn) {
+        instruments.add(v.instrument);
+      }
+    });
+    return [...instruments];
+  }, [data, selectedIgsn]);
+
+  useEffect(() => {
+    if (igsnOptions.length > 0 && !selectedIgsn) {
+      setSelectedIgsn(igsnOptions[0]);
+    }
+  }, [igsnOptions, selectedIgsn]);
+
+  useEffect(() => {
+    if (instrumentOptions.length > 0 && !instrumentOptions.includes(selectedInstrument)) {
+      setSelectedInstrument(instrumentOptions[0]);
+    }
+  }, [instrumentOptions, selectedInstrument]);
+
+  useEffect(() => {
+    if (!selectedIgsn) return;
+    setLoading(true);
+    const url = new URL(`${API_CONFIG.baseUrl}/visualizations/sample/${selectedIgsn}`);
+    if (selectedInstrument) {
+      url.searchParams.set("instrument", selectedInstrument);
+    }
+    fetch(url)
+      .then((res) => res.json())
+      .then((json) => {
+        setFrames(json.items.map(mapApiViz));
+        setCurrentIndex(0);
+        setPlaying(false);
+      })
+      .catch(() => {
+        const filtered = data.filter(
+          (v) =>
+            (v.igsn || v.sample) === selectedIgsn &&
+            (!selectedInstrument || v.instrument === selectedInstrument)
+        );
+        setFrames(filtered);
+        setCurrentIndex(0);
+        setPlaying(false);
+      })
+      .finally(() => setLoading(false));
+  }, [selectedIgsn, selectedInstrument, data]);
+
+  useEffect(() => {
+    if (!playing || frames.length === 0) return;
+    const intervalMs = 1500 / speed;
+    const timer = setInterval(() => {
+      setCurrentIndex((prev) => (prev + 1) % frames.length);
+    }, intervalMs);
+    return () => clearInterval(timer);
+  }, [playing, speed, frames.length]);
+
+  const handleKeyDown = useCallback(
+    (e) => {
+      if (e.target.tagName === "SELECT") return;
+      switch (e.code) {
+        case "Space":
+          e.preventDefault();
+          setPlaying((p) => !p);
+          break;
+        case "ArrowLeft":
+          e.preventDefault();
+          setPlaying(false);
+          setCurrentIndex((prev) => (prev - 1 + frames.length) % frames.length);
+          break;
+        case "ArrowRight":
+          e.preventDefault();
+          setPlaying(false);
+          setCurrentIndex((prev) => (prev + 1) % frames.length);
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setSpeed((s) => {
+            const idx = SPEEDS.indexOf(s);
+            return idx < SPEEDS.length - 1 ? SPEEDS[idx + 1] : s;
+          });
+          break;
+        case "ArrowDown":
+          e.preventDefault();
+          setSpeed((s) => {
+            const idx = SPEEDS.indexOf(s);
+            return idx > 0 ? SPEEDS[idx - 1] : s;
+          });
+          break;
+      }
+    },
+    [frames.length]
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
+  const currentFrame = frames[currentIndex] || null;
+  const instrumentColor =
+    currentFrame && INSTRUMENT_COLORS[currentFrame.instrument]
+      ? INSTRUMENT_COLORS[currentFrame.instrument]
+      : "#4ECDC4";
+
+  const selectStyle = {
+    background: "#0d1220",
+    border: "1px solid #1e2740",
+    borderRadius: "5px",
+    color: "#c8d3e8",
+    fontFamily: "'IBM Plex Mono', monospace",
+    fontSize: "12px",
+    padding: "6px 10px",
+    cursor: "pointer",
+  };
+
+  const buttonStyle = (active) => ({
+    background: active ? `${instrumentColor}20` : "transparent",
+    border: `1px solid ${active ? instrumentColor + "60" : "#1e2740"}`,
+    borderRadius: "5px",
+    color: active ? instrumentColor : "#4a5672",
+    fontFamily: "'IBM Plex Mono', monospace",
+    fontSize: "16px",
+    padding: "6px 12px",
+    cursor: "pointer",
+    transition: "all 0.2s",
+    lineHeight: 1,
+  });
+
+  return (
+    <div style={{ animation: "slideIn 0.3s ease" }}>
+      <div
+        style={{
+          display: "flex",
+          gap: "12px",
+          alignItems: "center",
+          marginBottom: "16px",
+          flexWrap: "wrap",
+        }}
+      >
+        <label style={{ fontFamily: "'IBM Plex Mono', monospace", fontSize: "11px", color: "#4a5672" }}>
+          SAMPLE
+          <select
+            value={selectedIgsn || ""}
+            onChange={(e) => setSelectedIgsn(e.target.value)}
+            style={{ ...selectStyle, marginLeft: "8px" }}
+          >
+            {igsnOptions.map((igsn) => (
+              <option key={igsn} value={igsn}>
+                {igsn}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label style={{ fontFamily: "'IBM Plex Mono', monospace", fontSize: "11px", color: "#4a5672" }}>
+          INSTRUMENT
+          <select
+            value={selectedInstrument || ""}
+            onChange={(e) => setSelectedInstrument(e.target.value)}
+            style={{ ...selectStyle, marginLeft: "8px" }}
+          >
+            {instrumentOptions.map((inst) => (
+              <option key={inst} value={inst}>
+                {inst}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <span
+          style={{
+            fontFamily: "'IBM Plex Mono', monospace",
+            fontSize: "11px",
+            color: "#3d4d6b",
+            marginLeft: "auto",
+          }}
+        >
+          {frames.length} position{frames.length !== 1 ? "s" : ""} | SPACE play/pause | ← → step | ↑ ↓ speed
+        </span>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          minHeight: "420px",
+          background: "#0a0f1a",
+          borderRadius: "8px",
+          border: "1px solid #1e2740",
+          marginBottom: "16px",
+          position: "relative",
+        }}
+      >
+        {loading ? (
+          <span style={{ color: "#4a5672", fontFamily: "'IBM Plex Mono', monospace", fontSize: "13px" }}>
+            Loading...
+          </span>
+        ) : frames.length === 0 ? (
+          <span style={{ color: "#4a5672", fontFamily: "'IBM Plex Mono', monospace", fontSize: "13px" }}>
+            No positions found for this sample
+          </span>
+        ) : currentFrame ? (
+          <div style={{ textAlign: "center", padding: "20px" }}>
+            {currentFrame.imageUrl ? (
+              <img
+                src={currentFrame.imageUrl}
+                alt={currentFrame.vizType}
+                style={{
+                  maxWidth: "100%",
+                  maxHeight: "360px",
+                  objectFit: "contain",
+                  borderRadius: "4px",
+                }}
+              />
+            ) : (
+              <div style={{ width: "400px", height: "300px" }}>
+                <MockVisualization viz={currentFrame} />
+              </div>
+            )}
+          </div>
+        ) : null}
+      </div>
+
+      {frames.length > 0 && (
+        <div
+          style={{
+            background: "#0d1220",
+            borderRadius: "8px",
+            border: "1px solid #1e2740",
+            padding: "12px 16px",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+              justifyContent: "center",
+              marginBottom: "12px",
+            }}
+          >
+            <button
+              onClick={() => { setPlaying(false); setCurrentIndex(0); }}
+              style={buttonStyle(false)}
+              title="First"
+            >
+              ⏮
+            </button>
+            <button
+              onClick={() => {
+                setPlaying(false);
+                setCurrentIndex((prev) => (prev - 1 + frames.length) % frames.length);
+              }}
+              style={buttonStyle(false)}
+              title="Previous"
+            >
+              ◀
+            </button>
+            <button
+              onClick={() => setPlaying((p) => !p)}
+              style={buttonStyle(playing)}
+              title={playing ? "Pause" : "Play"}
+            >
+              {playing ? "⏸" : "▶"}
+            </button>
+            <button
+              onClick={() => {
+                setPlaying(false);
+                setCurrentIndex((prev) => (prev + 1) % frames.length);
+              }}
+              style={buttonStyle(false)}
+              title="Next"
+            >
+              ▶
+            </button>
+            <button
+              onClick={() => { setPlaying(false); setCurrentIndex(frames.length - 1); }}
+              style={buttonStyle(false)}
+              title="Last"
+            >
+              ⏭
+            </button>
+
+            <div
+              style={{
+                marginLeft: "16px",
+                display: "flex",
+                gap: "4px",
+                alignItems: "center",
+                flex: 1,
+                maxWidth: "400px",
+              }}
+            >
+              {frames.map((_, i) => (
+                <div
+                  key={i}
+                  onClick={() => { setPlaying(false); setCurrentIndex(i); }}
+                  style={{
+                    flex: 1,
+                    height: i === currentIndex ? "10px" : "6px",
+                    background: i === currentIndex ? instrumentColor : i < currentIndex ? `${instrumentColor}60` : "#1e2740",
+                    borderRadius: "3px",
+                    cursor: "pointer",
+                    transition: "all 0.15s",
+                    minWidth: "4px",
+                  }}
+                />
+              ))}
+            </div>
+
+            <span
+              style={{
+                fontFamily: "'IBM Plex Mono', monospace",
+                fontSize: "12px",
+                color: "#c8d3e8",
+                minWidth: "50px",
+                textAlign: "right",
+              }}
+            >
+              {currentIndex + 1}/{frames.length}
+            </span>
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              fontFamily: "'IBM Plex Mono', monospace",
+              fontSize: "11px",
+            }}
+          >
+            <div style={{ display: "flex", gap: "12px", color: "#4a5672" }}>
+              <span>
+                speed:{" "}
+                {SPEEDS.map((s) => (
+                  <span
+                    key={s}
+                    onClick={() => setSpeed(s)}
+                    style={{
+                      color: s === speed ? instrumentColor : "#4a5672",
+                      cursor: "pointer",
+                      padding: "2px 4px",
+                    }}
+                  >
+                    {s}x
+                  </span>
+                ))}
+              </span>
+            </div>
+            <div style={{ display: "flex", gap: "16px" }}>
+              {currentFrame.position && (
+                <span style={{ color: "#6b7a99" }}>
+                  Position: <span style={{ color: instrumentColor }}>{currentFrame.position}</span>
+                </span>
+              )}
+              <span style={{ color: "#6b7a99" }}>
+                {currentFrame.igsn || currentFrame.sample}
+              </span>
+              <span style={{ color: instrumentColor }}>
+                {currentFrame.instrument}
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ViewModeSelector.jsx
+++ b/frontend/src/components/ViewModeSelector.jsx
@@ -3,6 +3,7 @@ export default function ViewModeSelector({ mode, setMode }) {
     { key: "stream", label: "Live Stream", icon: "◉" },
     { key: "spotlight", label: "Spotlight", icon: "◎" },
     { key: "sample", label: "By Sample", icon: "⊞" },
+    { key: "movie", label: "Movie", icon: "▶" },
   ];
   return (
     <div style={{ display: "flex", gap: "4px" }}>

--- a/frontend/src/hooks/useVizStream.js
+++ b/frontend/src/hooks/useVizStream.js
@@ -23,7 +23,7 @@ export function generateMockViz(id) {
   };
 }
 
-function mapApiViz(viz) {
+export function mapApiViz(viz) {
   return {
     id: viz.id,
     instrument: viz.instrument,
@@ -38,6 +38,7 @@ function mapApiViz(viz) {
     metadata: viz.metadata,
     pairKey: viz.pair_key || null,
     pairRole: viz.pair_role || null,
+    position: viz.position || null,
     status: "complete",
   };
 }


### PR DESCRIPTION
## Summary

- New **Movie** view mode that animates through all measurement positions for a selected sample, revealing spatial variation across the sample surface
- Backend extracts position identifiers from MAXIMA and HELIX folder names, adds `position` field to Visualization model
- New endpoint `GET /api/visualizations/sample/{igsn}` returns all positions sorted naturally

## Changes

**Backend:**
- `_extract_position()` in `discovery.py` — parses position from MAXIMA (`0_765`) and HELIX (`shot05`) folder names
- `position` field added to all viz dicts and the `Visualization` Pydantic model
- New `SampleVisualizationList` model and `/api/visualizations/sample/{igsn}` endpoint with natural position sorting

**Frontend:**
- Movie mode added to `ViewModeSelector` (▶ icon)
- `MovieView.jsx` component with:
  - Sample/instrument selector dropdowns
  - Play/pause, forward/back, first/last controls
  - Position scrubber bar with clickable segments
  - Speed control (0.5x, 1x, 2x, 4x)
  - Keyboard shortcuts (Space, ←/→, ↑/↓)
  - Large centered image display with metadata overlay
  - Falls back to local data when API unavailable
- `mapApiViz` exported from `useVizStream.js` for reuse
- `position` mapped through in `useVizStream`

## Test plan

- [x] Play/pause animates through positions sequentially
- [ ] Speed control works (0.5x through 4x)
- [ ] Scrubber bar allows jumping to specific positions
- [ ] Keyboard shortcuts (Space, arrows) work
- [ ] Works with both MAXIMA and HELIX data
- [ ] Handles samples with single or zero positions gracefully
- [ ] Falls back to mock data when backend unavailable
- [ ] No regressions in other view modes (stream, spotlight, sample)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)