### PR TITLE
build: package backend for PyPI as aimdl-dashboard-api

### DIFF
--- a/backend/MANIFEST.in
+++ b/backend/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE
+include README.md
+recursive-include src *.py

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,14 +1,50 @@
-# AIMD-L Dashboard Backend
+# aimdl-dashboard-api
 
-FastAPI service that authenticates to Girder, discovers visualization PNGs,
-and proxies image downloads to the frontend.
+FastAPI backend for the [AIMD-L visualization dashboard](https://github.com/htmdec/aimdl_dashboard),
+the real-time laboratory dashboard for the Autonomous Instrumented Materials Discovery
+Laboratory (AIMD-L) at Johns Hopkins University.
 
-## Setup
+The backend authenticates to the [HTMDEC Girder data portal](https://data.htmdec.org),
+walks instrument folder hierarchies (MAXIMA, HELIX, SPHINX), and proxies visualization
+PNGs to the frontend so the browser never needs Girder credentials.
+
+## Installation
 
 ```bash
-export AIMDL_API_KEY="your-key"
-pip install -e .
-./run.sh
+pip install aimdl-dashboard-api
 ```
 
-API runs at http://localhost:8000. See the top-level README for full instructions.
+## Usage
+
+Set your Girder API key (obtain from `https://data.htmdec.org` → Account → API Keys),
+then launch the server:
+
+```bash
+export AIMDL_API_KEY="your-key-here"
+aimdl-dashboard --port 8000
+```
+
+Options:
+
+```
+aimdl-dashboard --host 0.0.0.0 --port 8000 [--reload]
+```
+
+The API will be available at `http://localhost:8000/api` and the OpenAPI docs
+at `http://localhost:8000/docs`.
+
+## Environment variables
+
+| Variable         | Required | Description                                   |
+|------------------|----------|-----------------------------------------------|
+| `AIMDL_API_KEY`  | Yes      | Girder API key for `data.htmdec.org`          |
+| `GIRDER_API_URL` | No       | Override Girder API URL (default: htmdec.org) |
+
+## Documentation
+
+See the [main repository README](https://github.com/htmdec/aimdl_dashboard) for
+full architecture, frontend setup, kiosk deployment, and development notes.
+
+## License
+
+MIT

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,22 +1,56 @@
 [project]
 name = "aimdl-dashboard-api"
 version = "0.1.0"
+description = "FastAPI backend for the AIMD-L visualization dashboard"
+readme = "README.md"
+license = {text = "MIT"}
 requires-python = ">=3.9"
+authors = [
+    {name = "David Elbert", email = "elbert@jhu.edu"},
+]
+keywords = ["materials-science", "dashboard", "girder", "aimd-l", "visualization"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Framework :: FastAPI",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering",
+]
 dependencies = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.30",
     "girder-client>=3.2",
     "httpx>=0.27",
+    "requests>=2.28",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
-    "httpx>=0.27",
-    "ruff>=0.4",
     "coverage>=7.0",
+    "ruff>=0.4",
 ]
+
+[project.urls]
+Homepage = "https://github.com/htmdec/aimdl_dashboard"
+Repository = "https://github.com/htmdec/aimdl_dashboard"
+Issues = "https://github.com/htmdec/aimdl_dashboard/issues"
+
+[project.scripts]
+aimdl-dashboard = "aimdl_dashboard_api.cli:main"
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/backend/src/aimdl_dashboard_api/cli.py
+++ b/backend/src/aimdl_dashboard_api/cli.py
@@ -1,0 +1,46 @@
+"""CLI entry point for the AIMD-L Dashboard API."""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="AIMD-L Dashboard API server",
+    )
+    parser.add_argument("--host", default="0.0.0.0", help="Bind host")
+    parser.add_argument("--port", type=int, default=8000, help="Bind port")
+    parser.add_argument(
+        "--reload", action="store_true",
+        help="Enable auto-reload (dev only, may break Girder auth on macOS)",
+    )
+    args = parser.parse_args(argv)
+
+    if not os.environ.get("AIMDL_API_KEY"):
+        print("Error: AIMDL_API_KEY environment variable is required")
+        print("Get your key from https://data.htmdec.org -> Account -> API Keys")
+        sys.exit(1)
+
+    try:
+        import uvicorn
+    except ImportError:
+        print("uvicorn is required: pip install aimdl-dashboard-api")
+        sys.exit(1)
+
+    src_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if src_dir not in sys.path:
+        sys.path.insert(0, src_dir)
+
+    uvicorn.run(
+        "aimdl_dashboard_api.app:app",
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
+        log_level="info",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add full project metadata, classifiers, and URLs to pyproject.toml, introduce an aimdl-dashboard CLI entry point wrapping uvicorn, a MANIFEST.in, and a PyPI-friendly backend README.