### PR TITLE
feat: two-tier IGSN batch/sub-sample selector in Sample Comparison view

### DIFF
--- a/.claude/17a_sample_batch_view.md
+++ b/.claude/17a_sample_batch_view.md
@@ -1,0 +1,319 @@
+# Two-tier IGSN selector for Sample Comparison view
+
+**Branch:** `feat/igsn-batch-grouping`
+
+## Context
+
+AIMD-L IGSNs have a two-level structure: an 11-character base IGSN
+identifying a synthesis batch (e.g., `JHAMAL00016`) and an optional
+hyphen + suffix identifying a physical sub-sample (e.g., `-006`).
+The Sample Comparison view currently shows a flat list of full IGSN
+buttons. This task replaces it with a two-tier batch/sub-sample
+selector and adds a sort toggle.
+
+Frontend only — no backend changes.
+
+## Read these files first
+
+- `frontend/src/components/SampleComparisonView.jsx`
+- `frontend/src/components/VizCard.jsx`
+- `frontend/src/utils.js`
+- `frontend/src/config.js`
+- `frontend/src/components/__tests__/` (list directory to see patterns)
+- `frontend/src/components/__tests__/DataControls.test.jsx` (for style reference)
+- `frontend/src/test/setup.js`
+
+Do NOT read or modify backend files.
+
+## Task 1: Add IGSN parsing helper to utils.js
+
+Add two exported functions to `frontend/src/utils.js`:
+
+```javascript
+/**
+ * Parse an IGSN into its base (synthesis batch) and suffix (sub-sample).
+ * Examples:
+ *   "JHAMAL00016-006" → { base: "JHAMAL00016", suffix: "-006" }
+ *   "JHXMAL00005"     → { base: "JHXMAL00005", suffix: null }
+ *   ""                → { base: "", suffix: null }
+ */
+export function parseIgsn(igsn) {
+  if (!igsn) return { base: "", suffix: null };
+  const hyphenIdx = igsn.indexOf("-");
+  if (hyphenIdx === -1) return { base: igsn, suffix: null };
+  return {
+    base: igsn.slice(0, hyphenIdx),
+    suffix: igsn.slice(hyphenIdx),
+  };
+}
+
+/**
+ * Extract the unique base IGSN (11-char prefix) from a full IGSN.
+ */
+export function baseIgsn(igsn) {
+  return parseIgsn(igsn).base;
+}
+```
+
+Do NOT modify the existing `timeAgo` function.
+
+## Task 2: Rewrite SampleComparisonView.jsx
+
+Replace the entire component with a two-tier selector design. The new
+component must:
+
+### State
+
+- `selectedBatch` — the 11-character base IGSN (string or null)
+- `selectedSuffix` — `"ALL"` (default) or a specific suffix like `"-006"`
+- `sortMode` — `"suffix"` (default) or `"time"`
+
+### Derived data
+
+From the `data` prop, compute:
+
+- `batches` — a sorted array of unique base IGSNs. Derive using
+  `parseIgsn(v.sample || v.igsn).base` for each viz item. Filter out
+  empty strings.
+- `suffixesForBatch` — when a batch is selected, the sorted array of
+  unique suffixes (e.g., `["-005", "-006", "-007"]`) within that batch.
+  Include items with no suffix (suffix === null) as a "base" entry if
+  they exist.
+- `filteredData` — when `selectedSuffix === "ALL"`, all items whose
+  base IGSN matches `selectedBatch`. When a specific suffix is selected,
+  only items whose full IGSN matches `selectedBatch + selectedSuffix`.
+
+### Auto-selection
+
+- On mount or when `data` changes, auto-select the first batch if
+  nothing is selected.
+- When the selected batch changes, reset `selectedSuffix` to `"ALL"`.
+
+### Sorting
+
+Within each instrument column, sort the filtered items:
+- When `sortMode === "suffix"`: sort by suffix first (alphabetical),
+  then by timestamp within each suffix group.
+- When `sortMode === "time"`: sort by timestamp descending (newest first).
+
+### Layout
+
+**Top row — batch buttons:**
+```jsx
+<div style={{ display: "flex", gap: "6px", marginBottom: "10px", flexWrap: "wrap" }}>
+  {batches.map((batch) => (
+    <button key={batch} onClick={() => { setSelectedBatch(batch); setSelectedSuffix("ALL"); }}
+      style={{
+        padding: "6px 14px",
+        border: selectedBatch === batch ? "1px solid #FFE66D60" : "1px solid #1e2740",
+        borderRadius: "5px",
+        background: selectedBatch === batch ? "#FFE66D10" : "#0d1220",
+        color: selectedBatch === batch ? "#FFE66D" : "#4a5672",
+        fontFamily: "'IBM Plex Mono', monospace",
+        fontSize: "12px",
+        cursor: "pointer",
+        transition: "all 0.2s",
+      }}
+    >
+      {batch}
+    </button>
+  ))}
+</div>
+```
+
+**Second row — sub-sample pills + sort toggle:**
+
+Only render when a batch is selected and there are multiple suffixes
+(or at least one suffix). Show an `ALL` pill plus one pill per suffix.
+On the right side of this row, show a small sort toggle.
+
+```jsx
+<div style={{ display: "flex", gap: "6px", marginBottom: "16px", flexWrap: "wrap", alignItems: "center" }}>
+  {["ALL", ...suffixesForBatch].map((sfx) => (
+    <button key={sfx} onClick={() => setSelectedSuffix(sfx)}
+      style={{
+        padding: "4px 10px",
+        border: selectedSuffix === sfx ? "1px solid #4ECDC460" : "1px solid #1e2740",
+        borderRadius: "12px",
+        background: selectedSuffix === sfx ? "#4ECDC410" : "#0d1220",
+        color: selectedSuffix === sfx ? "#4ECDC4" : "#3d4d6b",
+        fontFamily: "'IBM Plex Mono', monospace",
+        fontSize: "11px",
+        cursor: "pointer",
+        transition: "all 0.2s",
+      }}
+    >
+      {sfx === "ALL" ? "ALL" : sfx}
+    </button>
+  ))}
+  <div style={{ marginLeft: "auto", display: "flex", gap: "4px" }}>
+    <button onClick={() => setSortMode("suffix")}
+      style={{
+        padding: "3px 8px",
+        border: "none",
+        borderRadius: "3px",
+        background: sortMode === "suffix" ? "#1e274080" : "transparent",
+        color: sortMode === "suffix" ? "#c8d3e8" : "#3d4d6b",
+        fontFamily: "'IBM Plex Mono', monospace",
+        fontSize: "10px",
+        cursor: "pointer",
+      }}
+    >
+      by sub-sample
+    </button>
+    <button onClick={() => setSortMode("time")}
+      style={{
+        padding: "3px 8px",
+        border: "none",
+        borderRadius: "3px",
+        background: sortMode === "time" ? "#1e274080" : "transparent",
+        color: sortMode === "time" ? "#c8d3e8" : "#3d4d6b",
+        fontFamily: "'IBM Plex Mono', monospace",
+        fontSize: "10px",
+        cursor: "pointer",
+      }}
+    >
+      by time
+    </button>
+  </div>
+</div>
+```
+
+The pill styling uses the teal accent (`#4ECDC4`) to distinguish
+sub-sample pills from the gold batch buttons. The sort toggle is
+minimal — two small text buttons on the right side of the pills row.
+
+**Instrument columns:**
+
+Keep the existing three-column grid layout with instrument headers.
+But remove the `items.slice(0, 3)` limit — show ALL filtered items
+in each column. When in `ALL` mode with `sortMode === "suffix"`, the
+cards will naturally group by sub-sample within each column.
+
+The rest of the column rendering (instrument header with colored dot,
+"No data" placeholder, VizCard rendering) stays the same as the
+current code.
+
+### Removing the old `.slice(0, 3)` limit
+
+The current code has `items.slice(0, 3)` which only shows 3 cards
+per instrument column. Remove this limit entirely. The columns are
+in a scrollable container (`overflow: auto` on the parent div in
+Dashboard.jsx), so showing all items is fine.
+
+## Task 3: Create tests
+
+**Create `frontend/src/components/__tests__/SampleComparisonView.test.jsx`**
+
+Test data factory — create a helper that generates viz items with
+specific IGSNs and instruments:
+
+```javascript
+function makeViz(id, { igsn = "JHAMAL00016-005", instrument = "HELIX" } = {}) {
+  return {
+    id,
+    instrument,
+    sample: igsn,
+    igsn,
+    vizType: `${id}.png`,
+    vizColor: "#fff",
+    timestamp: new Date().toISOString(),
+    imageUrl: null,
+    status: "complete",
+    pairKey: null,
+    pairRole: null,
+    position: null,
+    folderPath: `${instrument} / ${igsn}`,
+    fileId: `file_${id}`,
+    metadata: {},
+  };
+}
+```
+
+Test cases:
+
+1. **"renders batch buttons from data"** — pass data with items from
+   `JHAMAL00016-005`, `JHAMAL00016-006`, and `JHXMAL00005`. Verify
+   two batch buttons appear: `JHAMAL00016` and `JHXMAL00005`.
+
+2. **"renders sub-sample pills when batch is selected"** — pass data
+   with items from `-005`, `-006`, `-007` of the same batch. The
+   first batch should be auto-selected. Verify `ALL`, `-005`, `-006`,
+   `-007` pills are visible.
+
+3. **"ALL mode shows items from all sub-samples"** — pass data with
+   2 items from `-005` and 2 from `-006`. Verify all 4 items render
+   (not just 3 — the old slice limit is removed).
+
+4. **"selecting a suffix filters to that sub-sample"** — click a
+   specific suffix pill. Verify only items matching that full IGSN
+   are rendered.
+
+5. **"sort toggle switches between suffix and time order"** — render
+   with multiple sub-samples. Click "by time". Verify the toggle
+   button styling changes (the `by time` button gets the active
+   background).
+
+**Add IGSN helper tests to a new file
+`frontend/src/test/utils.test.js`:**
+
+1. **"parseIgsn splits base and suffix"** —
+   `parseIgsn("JHAMAL00016-006")` returns
+   `{ base: "JHAMAL00016", suffix: "-006" }`.
+
+2. **"parseIgsn handles no suffix"** —
+   `parseIgsn("JHXMAL00005")` returns
+   `{ base: "JHXMAL00005", suffix: null }`.
+
+3. **"parseIgsn handles empty string"** —
+   `parseIgsn("")` returns `{ base: "", suffix: null }`.
+
+4. **"parseIgsn handles null/undefined"** —
+   `parseIgsn(null)` and `parseIgsn(undefined)` both return
+   `{ base: "", suffix: null }`.
+
+5. **"baseIgsn returns just the prefix"** —
+   `baseIgsn("JHAMAL00016-006")` returns `"JHAMAL00016"`.
+
+## Task 4: Update README
+
+In the top-level `README.md`, find the "View modes" line in the
+"Dashboard Controls" section. Replace:
+
+```
+**View modes** — Live Stream (grid), Spotlight (focus), By Sample
+(grouped by IGSN), Movie (time-lapse).
+```
+
+with:
+
+```
+**View modes** — Live Stream (grid), Spotlight (focus), By Sample
+(two-tier selector: batch buttons group by synthesis conditions,
+sub-sample pills drill into individual pieces, with sort by
+sub-sample or time), Movie (time-lapse across positions).
+```
+
+## Verification
+
+```bash
+cd frontend
+npx vitest run src/test/utils.test.js
+npx vitest run src/components/__tests__/SampleComparisonView.test.jsx
+npx vitest run
+```
+
+All tests must pass, including all previously written tests.
+
+## Constraints
+
+- Do NOT modify any backend files
+- Do NOT modify VizCard.jsx, StreamView.jsx, MovieView.jsx, or
+  Dashboard.jsx — changes are only in SampleComparisonView.jsx and
+  utils.js
+- Do NOT change the existing `timeAgo` function in utils.js
+- Keep all existing styling conventions: dark background (#080c15 /
+  #0d1220), IBM Plex Mono for all text, gold (#FFE66D) for primary
+  selection, teal (#4ECDC4) for secondary selection, muted grey
+  (#4a5672 / #3d4d6b) for inactive elements
+- Commit message: `"feat: two-tier IGSN batch/sub-sample selector in Sample Comparison view"`

--- a/README.md
+++ b/README.md
@@ -220,7 +220,9 @@ a single instrument.
 and links to open the file or sample in the HTMDEC data portal.
 
 **View modes** — Live Stream (grid), Spotlight (focus), By Sample
-(grouped by IGSN), Movie (time-lapse).
+(two-tier selector: batch buttons group by synthesis conditions,
+sub-sample pills drill into individual pieces, with sort by
+sub-sample or time), Movie (time-lapse across positions).
 
 ## URL Parameters
 

--- a/frontend/src/components/SampleComparisonView.jsx
+++ b/frontend/src/components/SampleComparisonView.jsx
@@ -1,52 +1,161 @@
-import { useState } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { INSTRUMENTS, INSTRUMENT_COLORS, INSTRUMENT_DESCRIPTIONS } from "../config";
+import { parseIgsn } from "../utils";
 import VizCard from "./VizCard";
 
 export default function SampleComparisonView({ data }) {
-  const samples = [...new Set(data.map((v) => v.sample))].sort();
-  const [selectedSample, setSelectedSample] = useState(samples[0] || "A1");
+  const [selectedBatch, setSelectedBatch] = useState(null);
+  const [selectedSuffix, setSelectedSuffix] = useState("ALL");
+  const [sortMode, setSortMode] = useState("suffix");
 
-  const sampleData = data.filter((v) => v.sample === selectedSample);
-  const byInstrument = {};
-  INSTRUMENTS.forEach((inst) => {
-    byInstrument[inst.id] = sampleData
-      .filter((v) => v.instrument === inst.id)
-      .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
-  });
+  const batches = useMemo(() => {
+    const bases = new Set();
+    data.forEach((v) => {
+      const b = parseIgsn(v.sample || v.igsn).base;
+      if (b) bases.add(b);
+    });
+    return [...bases].sort();
+  }, [data]);
+
+  useEffect(() => {
+    if (batches.length > 0 && (!selectedBatch || !batches.includes(selectedBatch))) {
+      setSelectedBatch(batches[0]);
+      setSelectedSuffix("ALL");
+    }
+  }, [batches, selectedBatch]);
+
+  const suffixesForBatch = useMemo(() => {
+    if (!selectedBatch) return [];
+    const suffixes = new Set();
+    data.forEach((v) => {
+      const parsed = parseIgsn(v.sample || v.igsn);
+      if (parsed.base === selectedBatch) {
+        suffixes.add(parsed.suffix);
+      }
+    });
+    return [...suffixes].sort((a, b) => {
+      if (a === null) return -1;
+      if (b === null) return 1;
+      return a.localeCompare(b);
+    });
+  }, [data, selectedBatch]);
+
+  const filteredData = useMemo(() => {
+    if (!selectedBatch) return [];
+    return data.filter((v) => {
+      const parsed = parseIgsn(v.sample || v.igsn);
+      if (parsed.base !== selectedBatch) return false;
+      if (selectedSuffix === "ALL") return true;
+      return parsed.suffix === selectedSuffix;
+    });
+  }, [data, selectedBatch, selectedSuffix]);
+
+  const byInstrument = useMemo(() => {
+    const grouped = {};
+    INSTRUMENTS.forEach((inst) => {
+      const items = filteredData.filter((v) => v.instrument === inst.id);
+      if (sortMode === "suffix") {
+        items.sort((a, b) => {
+          const sa = parseIgsn(a.sample || a.igsn).suffix || "";
+          const sb = parseIgsn(b.sample || b.igsn).suffix || "";
+          const cmp = sa.localeCompare(sb);
+          if (cmp !== 0) return cmp;
+          return new Date(b.timestamp) - new Date(a.timestamp);
+        });
+      } else {
+        items.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+      }
+      grouped[inst.id] = items;
+    });
+    return grouped;
+  }, [filteredData, sortMode]);
 
   return (
     <div>
-      <div
-        style={{
-          display: "flex",
-          gap: "6px",
-          marginBottom: "20px",
-          flexWrap: "wrap",
-        }}
-      >
-        {samples.map((s) => (
+      <div style={{ display: "flex", gap: "6px", marginBottom: "10px", flexWrap: "wrap" }}>
+        {batches.map((batch) => (
           <button
-            key={s}
-            onClick={() => setSelectedSample(s)}
+            key={batch}
+            onClick={() => {
+              setSelectedBatch(batch);
+              setSelectedSuffix("ALL");
+            }}
             style={{
               padding: "6px 14px",
-              border:
-                selectedSample === s
-                  ? "1px solid #FFE66D60"
-                  : "1px solid #1e2740",
+              border: selectedBatch === batch ? "1px solid #FFE66D60" : "1px solid #1e2740",
               borderRadius: "5px",
-              background: selectedSample === s ? "#FFE66D10" : "#0d1220",
-              color: selectedSample === s ? "#FFE66D" : "#4a5672",
+              background: selectedBatch === batch ? "#FFE66D10" : "#0d1220",
+              color: selectedBatch === batch ? "#FFE66D" : "#4a5672",
               fontFamily: "'IBM Plex Mono', monospace",
               fontSize: "12px",
               cursor: "pointer",
               transition: "all 0.2s",
             }}
           >
-            {s}
+            {batch}
           </button>
         ))}
       </div>
+
+      {selectedBatch && suffixesForBatch.length > 0 && (
+        <div style={{ display: "flex", gap: "6px", marginBottom: "16px", flexWrap: "wrap", alignItems: "center" }}>
+          {["ALL", ...suffixesForBatch].map((sfx) => {
+            const key = sfx === null ? "__base__" : sfx;
+            return (
+              <button
+                key={key}
+                onClick={() => setSelectedSuffix(sfx)}
+                style={{
+                  padding: "4px 10px",
+                  border: selectedSuffix === sfx ? "1px solid #4ECDC460" : "1px solid #1e2740",
+                  borderRadius: "12px",
+                  background: selectedSuffix === sfx ? "#4ECDC410" : "#0d1220",
+                  color: selectedSuffix === sfx ? "#4ECDC4" : "#3d4d6b",
+                  fontFamily: "'IBM Plex Mono', monospace",
+                  fontSize: "11px",
+                  cursor: "pointer",
+                  transition: "all 0.2s",
+                }}
+              >
+                {sfx === "ALL" ? "ALL" : sfx === null ? "base" : sfx}
+              </button>
+            );
+          })}
+          <div style={{ marginLeft: "auto", display: "flex", gap: "4px" }}>
+            <button
+              onClick={() => setSortMode("suffix")}
+              style={{
+                padding: "3px 8px",
+                border: "none",
+                borderRadius: "3px",
+                background: sortMode === "suffix" ? "#1e274080" : "transparent",
+                color: sortMode === "suffix" ? "#c8d3e8" : "#3d4d6b",
+                fontFamily: "'IBM Plex Mono', monospace",
+                fontSize: "10px",
+                cursor: "pointer",
+              }}
+            >
+              by sub-sample
+            </button>
+            <button
+              onClick={() => setSortMode("time")}
+              style={{
+                padding: "3px 8px",
+                border: "none",
+                borderRadius: "3px",
+                background: sortMode === "time" ? "#1e274080" : "transparent",
+                color: sortMode === "time" ? "#c8d3e8" : "#3d4d6b",
+                fontFamily: "'IBM Plex Mono', monospace",
+                fontSize: "10px",
+                cursor: "pointer",
+              }}
+            >
+              by time
+            </button>
+          </div>
+        </div>
+      )}
+
       <div
         style={{
           display: "grid",
@@ -111,12 +220,10 @@ export default function SampleComparisonView({ data }) {
                       borderRadius: "8px",
                     }}
                   >
-                    No data for {selectedSample}
+                    No data for {selectedBatch}
                   </div>
                 ) : (
-                  items
-                    .slice(0, 3)
-                    .map((viz) => <VizCard key={viz.id} viz={viz} />)
+                  items.map((viz) => <VizCard key={viz.id} viz={viz} />)
                 )}
               </div>
             </div>

--- a/frontend/src/components/__tests__/SampleComparisonView.test.jsx
+++ b/frontend/src/components/__tests__/SampleComparisonView.test.jsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import SampleComparisonView from '../SampleComparisonView';
+
+function makeViz(id, { igsn = 'JHAMAL00016-005', instrument = 'HELIX' } = {}) {
+  return {
+    id,
+    instrument,
+    sample: igsn,
+    igsn,
+    vizType: `${id}.png`,
+    vizColor: '#fff',
+    timestamp: new Date().toISOString(),
+    imageUrl: null,
+    status: 'complete',
+    pairKey: null,
+    pairRole: null,
+    position: null,
+    folderPath: `${instrument} / ${igsn}`,
+    fileId: `file_${id}`,
+    metadata: {},
+  };
+}
+
+describe('SampleComparisonView', () => {
+  it('renders batch buttons from data', () => {
+    const data = [
+      makeViz('v1', { igsn: 'JHAMAL00016-005' }),
+      makeViz('v2', { igsn: 'JHAMAL00016-006' }),
+      makeViz('v3', { igsn: 'JHXMAL00005' }),
+    ];
+    render(<SampleComparisonView data={data} />);
+    expect(screen.getByText('JHAMAL00016')).toBeInTheDocument();
+    expect(screen.getByText('JHXMAL00005')).toBeInTheDocument();
+  });
+
+  it('renders sub-sample pills when batch is selected', () => {
+    const data = [
+      makeViz('v1', { igsn: 'JHAMAL00016-005' }),
+      makeViz('v2', { igsn: 'JHAMAL00016-006' }),
+      makeViz('v3', { igsn: 'JHAMAL00016-007' }),
+    ];
+    render(<SampleComparisonView data={data} />);
+    expect(screen.getByText('ALL')).toBeInTheDocument();
+    expect(screen.getByText('-005')).toBeInTheDocument();
+    expect(screen.getByText('-006')).toBeInTheDocument();
+    expect(screen.getByText('-007')).toBeInTheDocument();
+  });
+
+  it('ALL mode shows items from all sub-samples', () => {
+    const data = [
+      makeViz('v1', { igsn: 'JHAMAL00016-005' }),
+      makeViz('v2', { igsn: 'JHAMAL00016-005' }),
+      makeViz('v3', { igsn: 'JHAMAL00016-006' }),
+      makeViz('v4', { igsn: 'JHAMAL00016-006' }),
+    ];
+    render(<SampleComparisonView data={data} />);
+    expect(screen.getAllByText('v1.png').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('v2.png').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('v3.png').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('v4.png').length).toBeGreaterThan(0);
+  });
+
+  it('selecting a suffix filters to that sub-sample', async () => {
+    const user = userEvent.setup();
+    const data = [
+      makeViz('v1', { igsn: 'JHAMAL00016-005' }),
+      makeViz('v2', { igsn: 'JHAMAL00016-006' }),
+    ];
+    render(<SampleComparisonView data={data} />);
+    await user.click(screen.getByText('-005'));
+    expect(screen.getAllByText('v1.png').length).toBeGreaterThan(0);
+    expect(screen.queryAllByText('v2.png')).toHaveLength(0);
+  });
+
+  it('sort toggle switches between suffix and time order', async () => {
+    const user = userEvent.setup();
+    const data = [
+      makeViz('v1', { igsn: 'JHAMAL00016-005' }),
+      makeViz('v2', { igsn: 'JHAMAL00016-006' }),
+    ];
+    render(<SampleComparisonView data={data} />);
+    const byTimeBtn = screen.getByText('by time');
+    await user.click(byTimeBtn);
+    expect(byTimeBtn).toHaveStyle({ background: '#1e274080' });
+  });
+});

--- a/frontend/src/test/utils.test.js
+++ b/frontend/src/test/utils.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { parseIgsn, baseIgsn } from '../utils';
+
+describe('parseIgsn', () => {
+  it('splits base and suffix', () => {
+    expect(parseIgsn('JHAMAL00016-006')).toEqual({ base: 'JHAMAL00016', suffix: '-006' });
+  });
+
+  it('handles no suffix', () => {
+    expect(parseIgsn('JHXMAL00005')).toEqual({ base: 'JHXMAL00005', suffix: null });
+  });
+
+  it('handles empty string', () => {
+    expect(parseIgsn('')).toEqual({ base: '', suffix: null });
+  });
+
+  it('handles null/undefined', () => {
+    expect(parseIgsn(null)).toEqual({ base: '', suffix: null });
+    expect(parseIgsn(undefined)).toEqual({ base: '', suffix: null });
+  });
+});
+
+describe('baseIgsn', () => {
+  it('returns just the prefix', () => {
+    expect(baseIgsn('JHAMAL00016-006')).toBe('JHAMAL00016');
+  });
+});

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -1,3 +1,17 @@
+export function parseIgsn(igsn) {
+  if (!igsn) return { base: "", suffix: null };
+  const hyphenIdx = igsn.indexOf("-");
+  if (hyphenIdx === -1) return { base: igsn, suffix: null };
+  return {
+    base: igsn.slice(0, hyphenIdx),
+    suffix: igsn.slice(hyphenIdx),
+  };
+}
+
+export function baseIgsn(igsn) {
+  return parseIgsn(igsn).base;
+}
+
 export function timeAgo(isoStr) {
   const diff = Math.floor((Date.now() - new Date(isoStr).getTime()) / 1000);
   if (diff < 10) return "just now";


### PR DESCRIPTION
# Issue #6: Two-tier IGSN selector — batch grouping in Sample Comparison view

## Problem

The Sample Comparison view presents a flat list of full IGSN buttons
(e.g., `JHAMAL00016-005`, `JHAMAL00016-006`, `JHAMAL00016-007`). With
many sub-samples, this becomes a wall of buttons with no visible
structure. More importantly, there is no way to view all sub-samples
from the same synthesis batch side by side across instruments.

## Background: IGSN hierarchy

AIMD-L IGSNs have a two-level structure:

- **Base IGSN** (11 characters, e.g., `JHAMAL00016`): identifies a
  synthesis batch — all samples made under the same conditions in the
  same deposition run.
- **Sub-sample suffix** (hyphen + 3 digits, e.g., `-006`): identifies
  a physically distinct piece from that batch. Different pieces may
  come from different positions in the synthesis chamber or may be
  pieces of a larger sample that was sectioned.

Sub-samples within a batch share synthesis conditions but are
physically distinct and may show position-dependent variation in their
properties. Researchers frequently want to compare instrument data
across sub-samples within a batch to identify spatial gradients or
sample-to-sample variability.

## Expected Behavior

A two-tier selector replaces the flat IGSN button list:

**Top row — batch buttons:** One button per unique 11-character base
IGSN. Selecting a batch shows all its sub-samples.

**Second row — sub-sample pills:** Appears below the selected batch.
Shows `ALL` (default) plus individual suffix buttons (`-005`, `-006`,
etc.).

- **`ALL` selected:** Instrument columns show images from every
  sub-sample in the batch. Cards display their full IGSN for
  identification. Default sort: by suffix (so all `-005` cards group
  together within each column), with a toggle to sort by timestamp
  instead.
- **Specific suffix selected:** Works like the current view — shows
  data for one physical sample across instrument columns.

## Implementation Approach

**Frontend only — no backend changes.**

1. Add an IGSN helper to `utils.js`: `parseIgsn(igsn)` returns
   `{ base, suffix }` (or `{ base: igsn, suffix: null }` for IGSNs
   without a hyphen suffix).
2. Rewrite `SampleComparisonView.jsx`:
   - Derive batch groups from the data using the 11-char prefix.
   - Two-tier selector: batch buttons (top) → sub-sample pills (below).
   - `ALL` mode filters by base IGSN; individual mode filters by full IGSN.
   - Sort toggle: "By sub-sample" (default) vs "By time".
3. Add tests for the IGSN parsing helper and the batch grouping logic.

## Labels

`enhancement`, `frontend`
