### PR TITLE
Use session to download things twice as fast

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
+    "pytest-responses",
     "coverage>=7.0",
     "ruff>=0.4",
 ]

--- a/backend/src/aimdl_dashboard_api/girder_client.py
+++ b/backend/src/aimdl_dashboard_api/girder_client.py
@@ -1,5 +1,6 @@
 import io
 import logging
+import threading
 
 import requests
 from girder_client import GirderClient
@@ -12,11 +13,21 @@ logger = logging.getLogger(__name__)
 class GirderConnection:
     def __init__(self):
         self.client = None
+        self._local_thread = threading.local()
+
+    @property
+    def session(self):
+        if not hasattr(self._local_thread, "session"):
+            session = requests.Session()
+            session.headers.update({"User-Agent": "aimdl-dashboard/1.0"})
+            self._local_thread.session = session
+        return self._local_thread.session
 
     def connect(self):
         if not GIRDER_API_KEY:
             raise RuntimeError("AIMDL_API_KEY environment variable is not set")
         self.client = GirderClient(apiUrl=GIRDER_API_URL)
+        self.client._session = self.session
         self.client.authenticate(apiKey=GIRDER_API_KEY)
         logger.info("Connected to Girder at %s", GIRDER_API_URL)
 
@@ -38,9 +49,11 @@ class GirderConnection:
 
     def get_aimdl_counts(self):
         """Public endpoint — works even without auth."""
-        resp = requests.get(f"{GIRDER_API_URL}/aimdl/count", timeout=15)
-        resp.raise_for_status()
-        return resp.json()
+        try:
+            return self.client.get("aimdl/count")
+        except Exception as e:
+            logger.error("Failed to get AIMDL counts: %s", e)
+            raise e
 
     def get_item_files(self, item_id):
         return self.client.get(f"item/{item_id}/files")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 os.environ.setdefault("AIMDL_API_KEY", "test-key")
+os.environ.setdefault("GIRDER_API_URL", "http://localhost:8000/api/v1")
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 

--- a/backend/tests/test_girder_client.py
+++ b/backend/tests/test_girder_client.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+# from pytest_responses import responses
 from aimdl_dashboard_api.girder_client import GirderConnection
 
 
@@ -42,19 +44,28 @@ def test_get_aimdl_datafiles_params():
     assert params["sortdir"] == -1
 
 
-def test_get_aimdl_counts_calls_public_endpoint():
+def test_get_aimdl_counts_calls_public_endpoint(responses):
+    responses.add(
+        responses.POST,
+        f"{os.environ.get('GIRDER_API_URL')}/api_key/token",
+        status=200,
+        json={
+            "user": {"_id": "userId"},
+            "authToken": {"token": "token"},
+            "expires": "never",
+            "scope": ["all"],
+        },
+    )
+    responses.add(
+        responses.GET,
+        f"{os.environ.get('GIRDER_API_URL')}/aimdl/count",
+        status=200,
+        json={"pdv_alpss_output": 10, "xrd_derived": 20},
+    )
     conn = GirderConnection()
-    with patch("aimdl_dashboard_api.girder_client.requests.get") as mock_get:
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {"pdv_alpss_output": 10, "xrd_derived": 20}
-        mock_resp.raise_for_status = MagicMock()
-        mock_get.return_value = mock_resp
-
-        result = conn.get_aimdl_counts()
-
+    conn.connect()
+    result = conn.get_aimdl_counts()
     assert result == {"pdv_alpss_output": 10, "xrd_derived": 20}
-    mock_get.assert_called_once()
-    assert "/aimdl/count" in mock_get.call_args[0][0]
 
 
 def test_get_item_files():
@@ -78,12 +89,27 @@ def test_download_file_bytes():
     assert data == b"\x89PNG fake"
 
 
-def test_get_aimdl_counts_network_error():
+def test_get_aimdl_counts_network_error(responses):
+    responses.add(
+        responses.POST,
+        f"{os.environ.get('GIRDER_API_URL')}/api_key/token",
+        status=200,
+        json={
+            "user": {"_id": "userId"},
+            "authToken": {"token": "token"},
+            "expires": "never",
+            "scope": ["all"],
+        },
+    )
+    responses.add(
+        responses.GET,
+        f"{os.environ.get('GIRDER_API_URL')}/aimdl/count",
+        status=503,
+    )
     conn = GirderConnection()
-    with patch("aimdl_dashboard_api.girder_client.requests.get") as mock_get:
-        mock_get.side_effect = Exception("network down")
-        with pytest.raises(Exception, match="network down"):
-            conn.get_aimdl_counts()
+    conn.connect()
+    with pytest.raises(Exception, match="error 503"):
+        conn.get_aimdl_counts()
 
 
 def test_not_connected_by_default():


### PR DESCRIPTION
Always use `requests.Session` when doing a bazillion connections