### PR TITLE
Decrease the amount of Girder calls

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
+    "diskcache>=5.6",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.30",
     "girder-client>=3.2",

--- a/backend/src/aimdl_dashboard_api/app.py
+++ b/backend/src/aimdl_dashboard_api/app.py
@@ -14,7 +14,8 @@ from fastapi.responses import Response
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
-from .config import DISCOVERY_INTERVAL, DEFAULT_LIMIT
+from .config import DISCOVERY_INTERVAL, DEFAULT_LIMIT, IMAGE_CACHE_DIR, IMAGE_CACHE_MAX_MB
+from .file_cache import make_image_cache
 
 
 from .girder_client import girder
@@ -26,6 +27,12 @@ from .discovery import (
     get_cached_counts,
 )
 from .models import Visualization, VisualizationList, SampleVisualizationList
+
+
+image_cache = make_image_cache(
+    cache_dir=IMAGE_CACHE_DIR,
+    max_bytes=IMAGE_CACHE_MAX_MB * 1024 * 1024,
+)
 
 
 class RefreshRequest(BaseModel):
@@ -208,12 +215,21 @@ def get_visualization_image(item_id: str):
     if not viz:
         raise HTTPException(404, "Visualization not found in cache")
 
+    file_id = viz["file_id"]
+
+    cached = image_cache.get(file_id)
+    if cached is not None:
+        logger.debug("Image cache hit for file_id=%s", file_id)
+        return Response(content=cached, media_type="image/png")
+
     try:
-        data = girder.download_file_bytes(viz["file_id"])
-        return Response(content=data, media_type="image/png")
+        data = girder.download_file_bytes(file_id)
     except Exception as e:
         logger.exception("Failed to download image %s", item_id)
         raise HTTPException(502, f"Failed to download from Girder: {e}")
+
+    image_cache.set(file_id, data)
+    return Response(content=data, media_type="image/png")
 
 
 # Serve pre-built frontend in Docker (directory exists only inside the container)

--- a/backend/src/aimdl_dashboard_api/app.py
+++ b/backend/src/aimdl_dashboard_api/app.py
@@ -148,7 +148,6 @@ def list_visualizations(
             sample=v["sample"],
             folder_path=v["folder_path"],
             created=v["created"],
-            file_id=v["file_id"],
             thumbnail_url=f"/api/visualizations/{v['id']}/image",
             metadata=v["metadata"],
             pair_key=v.get("pair_key"),
@@ -190,7 +189,6 @@ def get_sample_visualizations(
             sample=v["sample"],
             folder_path=v["folder_path"],
             created=v["created"],
-            file_id=v["file_id"],
             thumbnail_url=f"/api/visualizations/{v['id']}/image",
             metadata=v["metadata"],
             pair_key=v.get("pair_key"),
@@ -215,20 +213,18 @@ def get_visualization_image(item_id: str):
     if not viz:
         raise HTTPException(404, "Visualization not found in cache")
 
-    file_id = viz["file_id"]
-
-    cached = image_cache.get(file_id)
+    cached = image_cache.get(item_id)
     if cached is not None:
-        logger.debug("Image cache hit for file_id=%s", file_id)
+        logger.debug("Image cache hit for item_id=%s", item_id)
         return Response(content=cached, media_type="image/png")
 
     try:
-        data = girder.download_file_bytes(file_id)
+        data = girder.download_item_bytes(item_id)
     except Exception as e:
         logger.exception("Failed to download image %s", item_id)
         raise HTTPException(502, f"Failed to download from Girder: {e}")
 
-    image_cache.set(file_id, data)
+    image_cache.set(item_id, data)
     return Response(content=data, media_type="image/png")
 
 

--- a/backend/src/aimdl_dashboard_api/config.py
+++ b/backend/src/aimdl_dashboard_api/config.py
@@ -12,3 +12,9 @@ DEFAULT_LIMIT = 30
 PER_INSTRUMENT_LIMIT = int(os.environ.get("PER_INSTRUMENT_LIMIT", "100"))
 
 DEFAULT_PER_INSTRUMENT = int(os.environ.get("DEFAULT_PER_INSTRUMENT", "30"))
+
+# --- Image file cache ---------------------------------------------------
+# Directory where downloaded Girder images are cached on disk.
+IMAGE_CACHE_DIR = os.environ.get("IMAGE_CACHE_DIR", "/tmp/aimdl_image_cache")
+# Maximum total disk space for the cache in megabytes.
+IMAGE_CACHE_MAX_MB = int(os.environ.get("IMAGE_CACHE_MAX_MB", "500"))

--- a/backend/src/aimdl_dashboard_api/discovery.py
+++ b/backend/src/aimdl_dashboard_api/discovery.py
@@ -44,7 +44,6 @@ _cache = {
 }
 
 _cache_by_id = {}
-_file_id_cache = {}
 
 
 def _fetch_datafiles(data_type, total_limit):
@@ -98,18 +97,6 @@ def _build_viz(item, data_type):
     igsn = meta.get("igsn") or ""
     item_id = item["_id"]
 
-    file_id = _file_id_cache.get(item_id)
-    if not file_id:
-        try:
-            files = girder.get_item_files(item_id)
-        except Exception:
-            logger.exception("Failed to fetch files for item %s", item_id)
-            return None
-        if not files:
-            return None
-        file_id = files[0]["_id"]
-        _file_id_cache[item_id] = file_id
-
     pair_key, pair_role = (None, None)
     if instrument == "MAXIMA":
         pair_key, pair_role = _extract_pair_info(name)
@@ -126,7 +113,6 @@ def _build_viz(item, data_type):
         "sample": igsn,
         "folder_path": f"{instrument} / {igsn}" if igsn else f"{instrument}",
         "created": created,
-        "file_id": file_id,
         "metadata": meta,
         "pair_key": pair_key,
         "pair_role": pair_role,

--- a/backend/src/aimdl_dashboard_api/file_cache.py
+++ b/backend/src/aimdl_dashboard_api/file_cache.py
@@ -1,0 +1,23 @@
+"""Image file cache backed by the ``diskcache`` package."""
+
+from __future__ import annotations
+
+import diskcache
+
+
+def make_image_cache(cache_dir: str, max_bytes: int) -> diskcache.Cache:
+    """Return a size-limited LRU disk cache for image bytes.
+
+    Parameters
+    ----------
+    cache_dir:
+        Directory used to store cached files.  Created if it does not exist.
+    max_bytes:
+        Maximum total disk space in bytes.  Least-recently-used entries are
+        evicted automatically when this limit would be exceeded.
+    """
+    return diskcache.Cache(
+        directory=cache_dir,
+        size_limit=max_bytes,
+        eviction_policy="least-recently-used",
+    )

--- a/backend/src/aimdl_dashboard_api/girder_client.py
+++ b/backend/src/aimdl_dashboard_api/girder_client.py
@@ -58,9 +58,12 @@ class GirderConnection:
     def get_item_files(self, item_id):
         return self.client.get(f"item/{item_id}/files")
 
-    def download_file_bytes(self, file_id):
+    def download_item_bytes(self, item_id):
         buf = io.BytesIO()
-        self.client.downloadFile(file_id, buf)
+        for chunk in self.client.sendRestRequest(
+            "GET", f"item/{item_id}/download", stream=True, jsonResp=False
+        ):
+            buf.write(chunk)
         buf.seek(0)
         return buf.read()
 

--- a/backend/src/aimdl_dashboard_api/models.py
+++ b/backend/src/aimdl_dashboard_api/models.py
@@ -12,7 +12,6 @@ class Visualization(BaseModel):
     sample: str
     folder_path: str
     created: datetime
-    file_id: str
     thumbnail_url: str
     metadata: dict = {}
     pair_key: Optional[str] = None

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -85,7 +85,6 @@ def mock_girder(helix_items, maxima_items, counts_data, item_files_data):
         discovery._cache["counts"] = {}
         discovery._cache["last_refresh"] = 0
         discovery._cache_by_id.clear()
-        discovery._file_id_cache.clear()
         yield mock
 
 
@@ -109,7 +108,6 @@ def sample_viz_data():
             "sample": "JHAMAL00016-002",
             "folder_path": "HELIX / JHAMAL00016-002",
             "created": "2026-04-13T22:42:49.000Z",
-            "file_id": "file_abc123",
             "metadata": {"igsn": "JHAMAL00016-002"},
             "pair_key": None,
             "pair_role": None,
@@ -123,7 +121,6 @@ def sample_viz_data():
             "sample": "JHXMAL00005",
             "folder_path": "MAXIMA / JHXMAL00005",
             "created": "2026-04-13T20:00:00.000Z",
-            "file_id": "file_def456",
             "metadata": {"igsn": "JHXMAL00005"},
             "pair_key": "scan_point_0_765",
             "pair_role": "xrd",

--- a/backend/tests/test_girder_client.py
+++ b/backend/tests/test_girder_client.py
@@ -68,24 +68,29 @@ def test_get_aimdl_counts_calls_public_endpoint(responses):
     assert result == {"pdv_alpss_output": 10, "xrd_derived": 20}
 
 
-def test_get_item_files():
+def test_download_item_bytes(responses):
+    responses.add(
+        responses.POST,
+        f"{os.environ.get('GIRDER_API_URL')}/api_key/token",
+        status=200,
+        json={
+            "user": {"_id": "userId"},
+            "authToken": {"token": "token"},
+            "expires": "never",
+            "scope": ["all"],
+        },
+    )
     conn = GirderConnection()
-    conn.client = MagicMock()
-    conn.client.get = MagicMock(return_value=[{"_id": "f1"}])
-    result = conn.get_item_files("item123")
-    conn.client.get.assert_called_once_with("item/item123/files")
-    assert result == [{"_id": "f1"}]
+    conn.connect()
 
+    responses.add(
+        responses.GET,
+        f"{os.environ.get('GIRDER_API_URL')}/item/file_abc/download",
+        status=200,
+        body=b"\x89PNG fake",
+    )
 
-def test_download_file_bytes():
-    conn = GirderConnection()
-    conn.client = MagicMock()
-
-    def fake_download(file_id, buf):
-        buf.write(b"\x89PNG fake")
-
-    conn.client.downloadFile = MagicMock(side_effect=fake_download)
-    data = conn.download_file_bytes("file_abc")
+    data = conn.download_item_bytes("file_abc")
     assert data == b"\x89PNG fake"
 
 

--- a/frontend/src/hooks/__tests__/useVizStream.test.js
+++ b/frontend/src/hooks/__tests__/useVizStream.test.js
@@ -9,7 +9,6 @@ const apiItem = {
   name: 'XRD Pattern',
   created: '2026-03-23T15:59:06Z',
   folder_path: 'AIMD-L/MAXIMA/automatic_mode/foo',
-  file_id: 'f1',
   metadata: {},
 };
 

--- a/frontend/src/hooks/useVizStream.js
+++ b/frontend/src/hooks/useVizStream.js
@@ -34,7 +34,6 @@ export function mapApiViz(viz) {
     imageUrl: `${API_CONFIG.baseUrl}/visualizations/${viz.id}/image`,
     folderPath: viz.folder_path,
     igsn: viz.igsn,
-    fileId: viz.file_id,
     metadata: viz.metadata,
     pairKey: viz.pair_key || null,
     pairRole: viz.pair_role || null,


### PR DESCRIPTION
This PR aims to significantly reduce number of Girder calls in order to make it more smooth for multiple users in production without putting a strain on Girder instance. Two main improvements:

1. Files are now fetched from Girder based on their `itemId`. `fileId` usage was removed entirely as it's unnecessary in this case. This removes 1 GET call for each png.
2. Images are now cached on aimdl-dashboard side using standard `diskcache` approach. This reduces N calls for each png and each user to 1 GET call for each png.